### PR TITLE
Replace confusing element to make it more organize

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ The main purpose of this module is to provide a PuppetDB import source
 for Icinga Director. As of this writing it has not even a GUI or CLI
 component, but this may change in future.
 
+To install, please refer to our documentation. [Installation and configuration](doc/01-Installation.md)
+Note: Some steps require you to be familiar with Puppet/PuppetDB. 
+
+
+==========
+
+Screnshot:
 ![Icinga Director PuppetDB import](doc/screenshot/puppetdb/readme/puppetdb_define_import.png)
 
-If this is what you're looking for please read more about [Installation and configuration](doc/01-Installation.md)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ for Icinga Director. As of this writing it has not even a GUI or CLI
 component, but this may change in future.
 
 To install, please refer to our documentation. [Installation and configuration](doc/01-Installation.md)
+
 Note: Some steps require you to be familiar with Puppet/PuppetDB. 
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Icinga Web 2 PuppetDB module
-============================
+# Icinga Web 2 PuppetDB module
+
 
 The main purpose of this module is to provide a PuppetDB import source
 for Icinga Director. As of this writing it has not even a GUI or CLI
@@ -7,11 +7,10 @@ component, but this may change in future.
 
 To install, please refer to our documentation. [Installation and configuration](doc/01-Installation.md)
 
-Note: Some steps require you to be familiar with Puppet/PuppetDB. 
+_Note: Some steps require you to be familiar with Puppet/PuppetDB_
 
 
-==========
+## Screnshot:
 
-Screnshot:
 ![Icinga Director PuppetDB import](doc/screenshot/puppetdb/readme/puppetdb_define_import.png)
 


### PR DESCRIPTION
The documentation link is too close to the screenshot and the eyes think the URL is part of the screenshot making many people missing the install documentation link.  

It would be better to design the README to put the description and the documentation altogether and to put the screenshot at the very end of the document to keep thing organized and more intuitive.